### PR TITLE
Improve DistantCopCarSirens documentation

### DIFF
--- a/AUDIO/DistantCopCarSirens.md
+++ b/AUDIO/DistantCopCarSirens.md
@@ -10,8 +10,9 @@ void DISTANT_COP_CAR_SIRENS(BOOL value);
 ```
 
 ```
-If value is set to true, and ambient siren sound will be played.
+If value is set to true, an ambient siren sound will be played if another player is in a vehicle that has the emergency lights on, even if the vehicle has no actual siren.
 Appears to enable/disable an audio flag.
+Defaults to true.
 ```
 
 ## Parameters


### PR DESCRIPTION
The distant sirens when _any_ player had their emergency lights on (regardless of whether the vehicle actually has a siren) are annoying. At first I was unsure of whether this native would fix that problem (the description reads like it's just on/off) but after some testing it turns out:
- the default is `true`
- when set to `true`, it will only actually play the sound when _any_ player* has emergency lights on. If no-one has emergency lights on, the sound isn't played.
- when toggling it off while the sound is playing, the distant sirens actually fade out, and vice versa.

Usecase: we have a race grid of about 30 cars, plus 1 safety car which has emergency lights (only lights, no actual siren). All players _except_ the safety car player and the vehicles very near to it would hear constant or intermittent distant sirens. Setting it to false has resolved this issue.

NB: I'm not sure if this also affects NPC sirens. I only tested it with actual players.
NB2: feel free to add more commits before merging if you want to reword things.